### PR TITLE
fix: SomaConnect no longer imports SomaShade

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,14 +19,11 @@ GEN = "2S"
 LOOP = asyncio.get_event_loop()
 
 
-SHADE_LIST: set[SomaShade] = {
-    SomaShade(SomaConnect(HOST, PORT), shade[0], shade[1], shade[2], shade[3])
-    for shade in [
-        ("aa:aa:aa:bb:bb:bb", "Lounge", "shade", "2S"),
-        ("cc:cc:cc:dd:dd:dd", "Kitchen", "shade", "2S"),
-        ("ee:ee:ee:ff:ff:ff", "Bedroom", "shade", "2"),
-    ]
-}
+DEVICE_LIST: list[dict[str, str]] = [
+    {"name": "Lounge", "mac": "aa:aa:aa:bb:bb:bb", "type": "shade", "gen": "2S"},
+    {"name": "Kitchen", "mac": "cc:cc:cc:dd:dd:dd", "type": "shade", "gen": "2S"},
+    {"name": "Bedroom", "mac": "ee:ee:ee:ff:ff:ff", "type": "shade", "gen": "2"},
+]
 
 LIST_DEVICES_PAYLOAD = {
     "result": "success",

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -8,11 +8,11 @@ from aioresponses import aioresponses
 from aiosoma import SomaConnect
 
 from . import (
+    DEVICE_LIST,
     HOST,
     LIST_DEVICES_PAYLOAD,
     MAC,
     PORT,
-    SHADE_LIST,
     URL,
     gen_bad_state,
     gen_shade_state,
@@ -41,7 +41,7 @@ async def test_list_devices():
         )
         response = await soma.list_devices()
         assert isinstance(response, list)
-        assert (shade in SHADE_LIST for shade in response)
+        assert (device in DEVICE_LIST for device in response)
         mocked_response.assert_called_once()
 
 
@@ -53,7 +53,7 @@ async def test_failed_list_devices():
         mocked_response.get(f"{URL}/list_devices", payload=gen_bad_state())
         shade_list = await soma.list_devices()
         assert shade_list is None
-        assert soma.shades is None
+        assert soma.devices is None
 
 
 @pytest.mark.asyncio()

--- a/tests/test_shade.py
+++ b/tests/test_shade.py
@@ -6,18 +6,42 @@ import pytest
 from aioresponses import aioresponses
 from freezegun import freeze_time
 
-from . import MAC, URL, gen_bad_state, gen_shade_state, mocked_bad_shade, mocked_shade
+from aiosoma import SomaShade
+
+from . import (
+    DEVICE_LIST,
+    MAC,
+    URL,
+    gen_bad_state,
+    gen_shade_state,
+    mocked_bad_shade,
+    mocked_connect,
+    mocked_shade,
+)
 
 
-def test_class_properties():
+def test_somashade_class_properties():
     """Test the SomaShade class properties."""
-    shade = mocked_shade()
-    assert str(shade) == "Lounge: Shade 2S (aa:aa:aa:bb:bb:bb)"
-    assert repr(shade) == "<Lounge Shade 2S (aa:aa:aa:bb:bb:bb)>"
+
+    shades: set[SomaShade] = set()
+    for device in DEVICE_LIST:
+        shades.add(SomaShade(mocked_connect(), **device))
+
+    for shade in shades:
+
+        if shade.name == "Lounge":
+            assert str(shade) == "Lounge: Shade 2S (aa:aa:aa:bb:bb:bb)"
+            assert repr(shade) == "<Lounge Shade 2S (aa:aa:aa:bb:bb:bb)>"
+        elif shade.name == "Kitchen":
+            assert str(shade) == "Kitchen: Shade 2S (cc:cc:cc:dd:dd:dd)"
+            assert repr(shade) == "<Kitchen Shade 2S (cc:cc:cc:dd:dd:dd)>"
+        elif shade.name == "Bedroom":
+            assert str(shade) == "Bedroom: Shade 2 (ee:ee:ee:ff:ff:ff)"
+            assert repr(shade) == "<Bedroom Shade 2 (ee:ee:ee:ff:ff:ff)>"
 
 
 @pytest.mark.asyncio()
-async def test_failed_result():
+async def test_bad_response():
     """Test failed result from SOMA Connect."""
     with aioresponses() as mock:
         shade = mocked_shade()


### PR DESCRIPTION
Refactored list_devices() to return a dictionary instead of a list of SomaShade objects. Tests refactored to instantiate SomaShade objects from the dictionary provided by list_devices().

Signed-off-by: Avi Miller <me@dje.li>